### PR TITLE
Upload APK as GitHub release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,12 @@ jobs:
         with:
           name: android-app
           path: build/app/outputs/flutter-apk/app-release.apk
+
+      - name: GitHub release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{secrets.GITHUB_TOKEN}}"
+          automatic_release_tag: "latest"
+          prerelease: false
+          title: "NocoDB Mobile (Unofficial prototype)"
+          files: "build/app/outputs/flutter-apk/app-release.apk"


### PR DESCRIPTION
This allows having a permanent, static download location like [this](https://github.com/ThreeDeeJay/nocodb-mobile/releases/download/latest/app-release.apk) that's [easier to find](https://github.com/ThreeDeeJay/nocodb-mobile/releases), doesn't require logging in and allows updating using [Obtainium](https://github.com/ImranR98/Obtainium) (which [hasn't implemented GitHub actions compatibility yet](https://github.com/ImranR98/Obtainium/issues/102#issuecomment-1556168328))